### PR TITLE
Escaping name of target table in CONSTRAINT reference.

### DIFF
--- a/MSAccess-VCS/VCS_Table.bas
+++ b/MSAccess-VCS/VCS_Table.bas
@@ -163,7 +163,7 @@ Private Function formatReferences(Db As Database, ff As Object, tableName As Str
         If (rel.foreignTable = tableName) Then
          If FieldsIdentical(ff, rel.Fields) Then
           sql = " REFERENCES "
-          sql = sql & rel.table & " ("
+          sql = sql & strName(rel.table) & " ("
           For Each f In rel.Fields
             sql = sql & strName(f.name) & ","
           Next


### PR DESCRIPTION
Found that table names weren't being escaped in the REFERENCES part of a CONSTRAINT clause while attempting to import a table with an FK on another table with a space in its name.