### PR TITLE
Update VCS_Reference.bas

### DIFF
--- a/MSAccess-VCS/VCS_ImportExport.bas
+++ b/MSAccess-VCS/VCS_ImportExport.bas
@@ -119,8 +119,8 @@ Public Sub ExportAllSource()
     VCS_Dir.MkDirIfNotExist Left(obj_path, InStrRev(obj_path, "\"))
     VCS_Dir.ClearTextFilesFromDir obj_path, "txt"
     
-    Dim td As TableDef
-    Dim tds As TableDefs
+    Dim td As DAO.TableDef
+    Dim tds As DAO.TableDefs
     Set tds = Db.TableDefs
 
     obj_type_label = "tbldef"
@@ -183,7 +183,7 @@ Err_TableNotFound:
 
     VCS_Dir.ClearTextFilesFromDir obj_path, "txt"
 
-    Dim aRelation As Relation
+    Dim aRelation As DAO.Relation
     
     For Each aRelation In CurrentDb.Relations
         If Not (aRelation.name = "MSysNavPaneGroupsMSysNavPaneGroupToObjects" Or aRelation.name = "MSysNavPaneGroupCategoriesMSysNavPaneGroups") Then
@@ -441,7 +441,7 @@ On Error GoTo errorHandler
     Debug.Print "Deleting Existing Objects"
     Debug.Print
     
-    Dim rel As Relation
+    Dim rel As DAO.Relation
     For Each rel In CurrentDb.Relations
         If Not (rel.name = "MSysNavPaneGroupsMSysNavPaneGroupToObjects" Or rel.name = "MSysNavPaneGroupCategoriesMSysNavPaneGroups") Then
             CurrentDb.Relations.Delete (rel.name)
@@ -457,7 +457,7 @@ On Error GoTo errorHandler
         End If
     Next
     
-    Dim td As TableDef
+    Dim td As DAO.TableDef
     For Each td In CurrentDb.TableDefs
         If Left$(td.name, 4) <> "MSys" And _
             Left(td.name, 1) <> "~" Then

--- a/MSAccess-VCS/VCS_Reference.bas
+++ b/MSAccess-VCS/VCS_Reference.bas
@@ -55,8 +55,9 @@ failed_guid:
     End If
     
 End Function
+
 ' Export References to a CSV
-    Public Function ExportReferences(obj_path As String)
+Public Function ExportReferences(obj_path As String)
     Dim FSO, outfile
     Dim line As String
     Dim ref As Reference

--- a/MSAccess-VCS/VCS_Reference.bas
+++ b/MSAccess-VCS/VCS_Reference.bas
@@ -57,7 +57,7 @@ failed_guid:
 End Function
 ' Export References to a CSV
     Public Function ExportReferences(obj_path As String)
-    Dim FSO, outfile
+    Dim FSO, Outfile
     Dim line As String
     Dim ref As Reference
     

--- a/MSAccess-VCS/VCS_Reference.bas
+++ b/MSAccess-VCS/VCS_Reference.bas
@@ -57,7 +57,7 @@ failed_guid:
 End Function
 
 ' Export References to a CSV
-Public Function ExportReferences(obj_path As String)
+Public Sub ExportReferences(obj_path As String)
     Dim FSO, outfile
     Dim line As String
     Dim ref As Reference
@@ -76,4 +76,4 @@ Public Function ExportReferences(obj_path As String)
         End If
     Next
     outfile.Close
-End Function
+End Sub

--- a/MSAccess-VCS/VCS_Reference.bas
+++ b/MSAccess-VCS/VCS_Reference.bas
@@ -56,23 +56,23 @@ failed_guid:
     
 End Function
 ' Export References to a CSV
-Public Function ExportReferences(obj_path As String)
-Dim FSO, outfile
-Dim line As String
-Dim ref As Reference
-
-Set FSO = CreateObject("Scripting.FileSystemObject")
-Set outfile = FSO.CreateTextFile(obj_path & "references.csv", True)
-For Each ref In Application.References
-    If ref.GUID > "" Then ' references of types mdb,accdb,mde etc don't have a GUID
-        If Not ref.BuiltIn Then
-            line = ref.GUID & "," & CStr(ref.Major) & "," & CStr(ref.Minor)
+    Public Function ExportReferences(obj_path As String)
+    Dim FSO, outfile
+    Dim line As String
+    Dim ref As Reference
+    
+    Set FSO = CreateObject("Scripting.FileSystemObject")
+    Set outfile = FSO.CreateTextFile(obj_path & "references.csv", True)
+    For Each ref In Application.References
+        If ref.GUID > "" Then ' references of types mdb,accdb,mde etc don't have a GUID
+            If Not ref.BuiltIn Then
+                line = ref.GUID & "," & CStr(ref.Major) & "," & CStr(ref.Minor)
+                outfile.WriteLine line
+            End If
+        Else
+            line = ref.FullPath
             outfile.WriteLine line
         End If
-    Else
-        line = ref.FullPath
-        outfile.WriteLine line
-    End If
-Next
-outfile.Close
+    Next
+    outfile.Close
 End Function

--- a/MSAccess-VCS/VCS_Reference.bas
+++ b/MSAccess-VCS/VCS_Reference.bas
@@ -58,22 +58,22 @@ End Function
 
 ' Export References to a CSV
 Public Sub ExportReferences(obj_path As String)
-    Dim FSO, Outfile
+    Dim FSO, OutFile
     Dim line As String
     Dim ref As Reference
     
     Set FSO = CreateObject("Scripting.FileSystemObject")
-    Set Outfile = FSO.CreateTextFile(obj_path & "references.csv", True)
+    Set OutFile = FSO.CreateTextFile(obj_path & "references.csv", True)
     For Each ref In Application.References
         If ref.GUID > "" Then ' references of types mdb,accdb,mde etc don't have a GUID
             If Not ref.BuiltIn Then
                 line = ref.GUID & "," & CStr(ref.Major) & "," & CStr(ref.Minor)
-                Outfile.WriteLine line
+                OutFile.WriteLine line
             End If
         Else
             line = ref.FullPath
-            Outfile.WriteLine line
+            OutFile.WriteLine line
         End If
     Next
-    Outfile.Close
+    OutFile.Close
 End Sub

--- a/MSAccess-VCS/VCS_Reference.bas
+++ b/MSAccess-VCS/VCS_Reference.bas
@@ -56,22 +56,23 @@ failed_guid:
     
 End Function
 ' Export References to a CSV
-Public Sub ExportReferences(obj_path As String)
-    Dim FSO, OutFile
-    Dim line As String
-    Dim ref As Reference
-    Set FSO = CreateObject("Scripting.FileSystemObject")
-    Set OutFile = FSO.CreateTextFile(obj_path & "references.csv", True)
-    For Each ref In Application.References
-        If ref.GUID > "" Then ' references of types mdb,accdb,mde etc don't have a GUID
-          line = ref.GUID & "," & CStr(ref.Major) & "," & CStr(ref.Minor)
-          OutFile.WriteLine line
-        Else
-          line = ref.FullPath
-          OutFile.WriteLine line
+Public Function ExportReferences(obj_path As String)
+Dim FSO, outfile
+Dim line As String
+Dim ref As Reference
+
+Set FSO = CreateObject("Scripting.FileSystemObject")
+Set outfile = FSO.CreateTextFile(obj_path & "references.csv", True)
+For Each ref In Application.References
+    If ref.GUID > "" Then ' references of types mdb,accdb,mde etc don't have a GUID
+        If Not ref.BuiltIn Then
+            line = ref.GUID & "," & CStr(ref.Major) & "," & CStr(ref.Minor)
+            outfile.WriteLine line
         End If
-    Next
-    OutFile.Close
-End Sub
-
-
+    Else
+        line = ref.FullPath
+        outfile.WriteLine line
+    End If
+Next
+outfile.Close
+End Function

--- a/MSAccess-VCS/VCS_Reference.bas
+++ b/MSAccess-VCS/VCS_Reference.bas
@@ -57,7 +57,7 @@ failed_guid:
 End Function
 ' Export References to a CSV
     Public Function ExportReferences(obj_path As String)
-    Dim FSO, Outfile
+    Dim FSO, outfile
     Dim line As String
     Dim ref As Reference
     

--- a/MSAccess-VCS/VCS_Reference.bas
+++ b/MSAccess-VCS/VCS_Reference.bas
@@ -58,22 +58,22 @@ End Function
 
 ' Export References to a CSV
 Public Sub ExportReferences(obj_path As String)
-    Dim FSO, outfile
+    Dim FSO, Outfile
     Dim line As String
     Dim ref As Reference
     
     Set FSO = CreateObject("Scripting.FileSystemObject")
-    Set outfile = FSO.CreateTextFile(obj_path & "references.csv", True)
+    Set Outfile = FSO.CreateTextFile(obj_path & "references.csv", True)
     For Each ref In Application.References
         If ref.GUID > "" Then ' references of types mdb,accdb,mde etc don't have a GUID
             If Not ref.BuiltIn Then
                 line = ref.GUID & "," & CStr(ref.Major) & "," & CStr(ref.Minor)
-                outfile.WriteLine line
+                Outfile.WriteLine line
             End If
         Else
             line = ref.FullPath
-            outfile.WriteLine line
+            Outfile.WriteLine line
         End If
     Next
-    outfile.Close
+    Outfile.Close
 End Sub

--- a/MSAccess-VCS/VCS_Relation.bas
+++ b/MSAccess-VCS/VCS_Relation.bas
@@ -3,7 +3,7 @@ Option Compare Database
 
 Option Explicit
 
-Public Sub ExportRelation(rel As Relation, filePath As String)
+Public Sub ExportRelation(rel As DAO.Relation, filePath As String)
     Dim FSO, OutFile As Object
     Set FSO = CreateObject("Scripting.FileSystemObject")
     Set OutFile = FSO.CreateTextFile(filePath, True)
@@ -12,7 +12,7 @@ Public Sub ExportRelation(rel As Relation, filePath As String)
     OutFile.WriteLine rel.name
     OutFile.WriteLine rel.table
     OutFile.WriteLine rel.foreignTable
-    Dim f As Field
+    Dim f As DAO.Field
     For Each f In rel.Fields
         OutFile.WriteLine "Field = Begin"
         OutFile.WriteLine f.name
@@ -29,15 +29,15 @@ Public Sub ImportRelation(filePath As String)
     Set FSO = CreateObject("Scripting.FileSystemObject")
     Set InFile = FSO.OpenTextFile(filePath, 1)
     
-    Dim rel As New Relation
+    Dim rel As New DAO.Relation
     rel.Attributes = InFile.ReadLine
     rel.name = InFile.ReadLine
     rel.table = InFile.ReadLine
     rel.foreignTable = InFile.ReadLine
-    Dim f As Field
+    Dim f As DAO.Field
     Do Until InFile.AtEndOfStream
         If "Field = Begin" = InFile.ReadLine Then
-            Set f = New Field
+            Set f = New DAO.Field
             f.name = InFile.ReadLine
             f.ForeignName = InFile.ReadLine
             If "End" <> InFile.ReadLine Then

--- a/MSAccess-VCS/VCS_Table.bas
+++ b/MSAccess-VCS/VCS_Table.bas
@@ -53,11 +53,11 @@ Public Sub ExportLinkedTable(tbl_name As String, obj_path As String)
     OutFile.Write vbCrLf
     
 
-    Dim Db As Database
+    Dim Db As DAO.Database
     Set Db = CurrentDb
-    Dim td As TableDef
+    Dim td As DAO.TableDef
     Set td = Db.TableDefs(tbl_name)
-    Dim idx As Index
+    Dim idx As DAO.Index
     
     For Each idx In td.Indexes
         If idx.Primary Then
@@ -89,11 +89,11 @@ Public Sub ExportTableDef(Db As Database, td As TableDef, tableName As String, d
     Dim fileName As String: fileName = directory & tableName & ".sql"
     Dim sql As String
     Dim fieldAttributeSql As String
-    Dim idx As Index
-    Dim fi As Field
+    Dim idx As DAO.Index
+    Dim fi As DAO.Field
     Dim i As Integer
-    Dim f As Field
-    Dim rel As Relation
+    Dim f As DAO.Field
+    Dim rel As DAO.Relation
     Dim FSO, OutFile
     Dim ff As Object
     'Debug.Print tableName
@@ -155,10 +155,10 @@ Public Sub ExportTableDef(Db As Database, td As TableDef, tableName As String, d
     
 End Sub
 
-Private Function formatReferences(Db As Database, ff As Object, tableName As String)
-    Dim rel As Relation
+Private Function formatReferences(Db As DAO.Database, ff As Object, tableName As String)
+    Dim rel As DAO.Relation
     Dim sql As String
-    Dim f As Field
+    Dim f As DAO.Field
     For Each rel In Db.Relations
         If (rel.foreignTable = tableName) Then
          If FieldsIdentical(ff, rel.Fields) Then
@@ -181,9 +181,9 @@ Private Function formatReferences(Db As Database, ff As Object, tableName As Str
     formatReferences = sql
 End Function
 
-Private Function formatConstraint(keyw As String, idx As Index) As String
+Private Function formatConstraint(keyw As String, idx As DAO.Index) As String
     Dim sql As String
-    Dim fi As Field
+    Dim fi As DAO.Field
     
     sql = strName(idx.name) & " " & keyw & " ("
     For Each fi In idx.Fields
@@ -236,7 +236,7 @@ Private Function strType(i As Integer) As String
     End Select
 End Function
 Private Function FieldsIdentical(ff As Object, gg As Object) As Boolean
-    Dim f As Field
+    Dim f As DAO.Field
     If ff.Count <> gg.Count Then
         FieldsIdentical = False
         Exit Function
@@ -252,8 +252,8 @@ Private Function FieldsIdentical(ff As Object, gg As Object) As Boolean
     
 End Function
 
-Private Function FieldInFields(fi As Field, ff As Fields) As Boolean
-    Dim f As Field
+Private Function FieldInFields(fi As DAO.Field, ff As DAO.Fields) As Boolean
+    Dim f As DAO.Field
     For Each f In ff
         If f.name = fi.name Then
             FieldInFields = True
@@ -323,7 +323,7 @@ End Function
 ' Export the lookup table `tblName` to `source\tables`.
 Public Sub ExportTableData(tbl_name As String, obj_path As String)
     Dim FSO, OutFile
-    Dim rs As Recordset ' DAO.Recordset
+    Dim rs As DAO.Recordset ' DAO.Recordset
     Dim fieldObj As Object ' DAO.Field
     Dim c As Long, Value As Variant
     ' Checks first
@@ -413,7 +413,7 @@ err_notable:
 err_notable_fin:
     On Error GoTo Err_CreateLinkedTable:
     
-    Dim td As TableDef
+    Dim td As DAO.TableDef
     Set td = Db.CreateTableDef(InFile.ReadLine())
     
     Dim connect As String


### PR DESCRIPTION
Removes the builtin references that cause an error when re-importing them, by not exporting them in the first place.