### PR TITLE
Fixes for linked tables

### DIFF
--- a/MSAccess-VCS/VCS_ImportExport.bas
+++ b/MSAccess-VCS/VCS_ImportExport.bas
@@ -135,6 +135,7 @@ Public Sub ExportAllSource()
     ' - We don't want to determin file extentions here - or obj_path either!
     VCS_Dir.ClearTextFilesFromDir obj_path, "sql"
     VCS_Dir.ClearTextFilesFromDir obj_path, "xml"
+    VCS_Dir.ClearTextFilesFromDir obj_path, "LNKD"
     Dim IncludeTablesCol As Collection: Set IncludeTablesCol = StrSetToCol(INCLUDE_TABLES, ",")
     Debug.Print VCS_String.PadRight("Exporting " & obj_type_label & "...", 24);
     
@@ -186,7 +187,8 @@ Err_TableNotFound:
     Dim aRelation As DAO.Relation
     
     For Each aRelation In CurrentDb.Relations
-        If Not (aRelation.name = "MSysNavPaneGroupsMSysNavPaneGroupToObjects" Or aRelation.name = "MSysNavPaneGroupCategoriesMSysNavPaneGroups") Then
+        ' Exclude relations from system and linked tables
+        If Not (aRelation.name = "MSysNavPaneGroupsMSysNavPaneGroupToObjects" Or aRelation.name = "MSysNavPaneGroupCategoriesMSysNavPaneGroups" Or Left(aRelation.name,1) = "[") Then
             VCS_Relation.ExportRelation aRelation, obj_path & aRelation.name & ".txt"
             obj_count = obj_count + 1
         End If


### PR DESCRIPTION
1) Previous exported files for linked tables are deleted before a new export, so deleted linked tables do not reappear in an import.
2) Relations coming from linked tables are excluded since they don't belong to the database being exported, but to the backend where the actual tables are defined. I think this is the sanest solution for the issue #10.