### PR TITLE
Support for DECIMAL types.

### DIFF
--- a/MSAccess-VCS/VCS_Table.bas
+++ b/MSAccess-VCS/VCS_Table.bas
@@ -83,6 +83,26 @@ Err_LinkedTable:
     Resume Err_LinkedTable_Fin:
 End Sub
 
+' This requires Microsoft ADO Ext. 2.x for DLL and Security
+' See reference: https://social.msdn.microsoft.com/Forums/office/en-US/883087ba-2c25-4571-bd3c-706061466a11/how-can-i-programmatically-access-scale-property-of-a-decimal-data-type-field?forum=accessdev
+Private Function formatDecimal(ByVal tableName As String, ByVal fieldName As String) As String
+
+    Dim cnn As New ADODB.Connection
+    Dim cat As New ADOX.Catalog
+    Dim col As ADOX.Column
+
+    Set cnn = CurrentProject.Connection
+    Set cat.ActiveConnection = cnn
+
+    Set col = cat.Tables(tableName).Columns(fieldName)
+
+    formatDecimal = "(" & col.Precision & ", " & col.NumericScale & ")"
+
+    Set col = Nothing
+    Set cat = Nothing
+    Set cnn = Nothing
+
+End Function
 
 ' Save a Table Definition as SQL statement
 Public Sub ExportTableDef(Db As Database, td As TableDef, tableName As String, directory As String)
@@ -110,6 +130,8 @@ Public Sub ExportTableDef(Db As Database, td As TableDef, tableName As String, d
         Select Case fi.Type
             Case dbText, dbVarBinary
                 sql = sql & "(" & fi.Size & ")"
+            Case dbDecimal
+                sql = sql & formatDecimal(tableName, fi.name)
             Case Else
         End Select
         For Each idx In td.Indexes
@@ -231,6 +253,8 @@ Private Function strType(i As Integer) As String
         strType = "NUMERIC"
     Case dbText
         strType = "VARCHAR"
+    Case dbDecimal
+        strType = "DECIMAL"
     Case Else
         strType = "VARCHAR"
     End Select
@@ -538,7 +562,7 @@ Public Sub ImportTableDef(tblName As String, directory As String)
         End If
     Next
     On Error GoTo 0
-    Db.Execute buf
+    CurrentProject.Connection.Execute buf
     InFile.Close
     If Len(strMsg) > 0 Then MsgBox strMsg, vbOKOnly, "Correct manually"
     

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For the purposes of these instructions, assume your database is called `Applicat
 e.g. `loadVCS "C:\Users\MyUserAccount\Documents\Access-Proj\MSAccess-VCS\"` - the trailing slash is required
 or `loadVCS`
 3. Edit your `VCS_ImportExport` and change the constant `INCLUDE_TABLES` to list any lookup tables that function more as part of your application code than as client data. (For example, "Countries", "Colors", and things like that.)
-4. Make sure there is a DAO reference - In the VBA editor, menu "Tools" > "References", select "Microsoft DAO 3.6 Object Library". Without this the "Database" references will cause compilation to fail with the message "Compile error: User-defined type not defined"
+4. Make sure there are references to DAO and ADOX - In the VBA editor, menu "Tools" > "References", select "Microsoft DAO 3.6 Object Library" and "Microsoft ADO Ext. 2.x for DLL and Security". Without this the "Database" and other references will cause compilation to fail with the message "Compile error: User-defined type not defined"
 5. If on compilation you get "Compile error: Method or data member not found" on "fi.Size" (Field), try re-ordering the dependencies to put ADO after DAO, as ADO (2.1) also defines field, but without the size member.
 
 Configuring export of table data


### PR DESCRIPTION
This needs reference to "Microsoft ADO Ext. 2.x for DLL and Security" and the importing of the SQL table definitions must be done with CurrentProject.Connection.Execute (ADODB.Connection).

This solve the issue #26. Tested exporting and importing with my backend (24 tables but after removing relations, since I am affected by issue #16), and with my front-end.

References:
https://social.msdn.microsoft.com/Forums/office/en-US/883087ba-2c25-4571-bd3c-706061466a11/how-can-i-programmatically-access-scale-property-of-a-decimal-data-type-field?forum=accessdev
http://stackoverflow.com/questions/180929/how-do-i-create-a-decimal-field-in-access-with-alter-table
