### PR TITLE
Add dbAttachSavePWD Attribute to ImportLinkedTable

### DIFF
--- a/MSAccess-VCS/VCS_Table.bas
+++ b/MSAccess-VCS/VCS_Table.bas
@@ -464,7 +464,7 @@ err_notable_fin:
     If InStr(1, connect, "DATABASE=.\") Then 'replace relative path with literal path
         connect = Replace(connect, "DATABASE=.\", "DATABASE=" & CurrentProject.Path & "\")
     End If
-    td.Attribute = dbAttachSavePWD
+    td.Attributes = dbAttachSavePWD
     td.connect = connect
     
     td.SourceTableName = InFile.ReadLine()

--- a/MSAccess-VCS/VCS_Table.bas
+++ b/MSAccess-VCS/VCS_Table.bas
@@ -464,6 +464,7 @@ err_notable_fin:
     If InStr(1, connect, "DATABASE=.\") Then 'replace relative path with literal path
         connect = Replace(connect, "DATABASE=.\", "DATABASE=" & CurrentProject.Path & "\")
     End If
+    td.Attribute = dbAttachSavePWD
     td.connect = connect
     
     td.SourceTableName = InFile.ReadLine()


### PR DESCRIPTION
Allows the import of Linked Tabled with ODBC parameters UID & PWD to have these saved with the linked table. Previously these were ignored by MS Access on ImportAllSource or ImportProject.
Ref. https://support.microsoft.com/en-us/kb/117536 & https://msdn.microsoft.com/en-us/library/office/ff194433.aspx
