### PR TITLE
Fixes localized exports of boolean values

### DIFF
--- a/MSAccess-VCS/VCS_Table.bas
+++ b/MSAccess-VCS/VCS_Table.bas
@@ -191,6 +191,8 @@ Public Sub VCS_ExportTableData(ByVal tbl_name As String, ByVal obj_path As Strin
             Value = rs(fieldObj.name)
             If IsNull(Value) Then
                 Value = vbNullString
+            ElseIf VarType(Value) = vbBoolean Then
+                Value = CInt(Value)
             Else
                 Value = Replace(Value, "\", "\\")
                 Value = Replace(Value, vbCrLf, "\n")


### PR DESCRIPTION
String conversion of boolean values unfortunately uses their localized names ("Vrai"/"Faux" in French, for example) for foreign versions of Access. Unfortunately, it doesn't import back correctly, and doesn't play well with other versions.

This patch fixes this by using the numerical constants for boolean values.