### PR TITLE
Delete tables on reimport

### DIFF
--- a/MSAccess-VCS/VCS_Table.bas
+++ b/MSAccess-VCS/VCS_Table.bas
@@ -296,6 +296,8 @@ End Sub
 Public Sub VCS_ImportTableDef(ByVal tblName As String, ByVal directory As String)
     Dim filePath As String
     
+    KillTable tblName, CurrentDb
+    
     filePath = directory & tblName & ".xml"
     Application.ImportXML DataSource:=filePath, ImportOptions:=acStructureOnly
 

--- a/MSAccess-VCS/VCS_Table.bas
+++ b/MSAccess-VCS/VCS_Table.bas
@@ -212,6 +212,13 @@ Public Sub VCS_ExportTableData(ByVal tbl_name As String, ByVal obj_path As Strin
     FSO.DeleteFile tempFileName
 End Sub
 
+' Kill Table if Exists
+Private Sub KillTable(ByVal tblName As String, Db As Object)
+    If TableExists(tblName) Then
+        Db.Execute "DROP TABLE [" & tblName & "]"
+    End If
+End Sub
+
 Public Sub VCS_ImportLinkedTable(ByVal tblName As String, ByRef obj_path As String)
     Dim Db As DAO.Database
     Dim FSO As Object


### PR DESCRIPTION
Calling "ImportAllSource" create duplicate tables (ie.: MyTable1 if MyTable already exist), and fill the original table with data. This issue was introduced on commit 2bf2b3c. This PR deletes the original table as per the old behavior.