### PR TITLE
fix link to Mercurial wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This README shows how to synchronize all application code objects from an Access
 
 Encoding
 --------
-For Access objects which are normally exported in `UCS-2-little-endian` encoding , the included module automatically converts to the source code to and from `UTF-8` encoding during export/import; this is to ensure that you don't have trouble branching, merging, and comparing in tools such as Mercurial which [treat any file containing 0x00 bytes as a non-diffable binary file](http://mercurial.selenic.com/wiki/BinaryFiles).
+For Access objects which are normally exported in `UCS-2-little-endian` encoding , the included module automatically converts to the source code to and from `UTF-8` encoding during export/import; this is to ensure that you don't have trouble branching, merging, and comparing in tools such as Mercurial which [treat any file containing 0x00 bytes as a non-diffable binary file](https://www.mercurial-scm.org/wiki/BinaryFiles).
 
 Output
 ------


### PR DESCRIPTION
The Mercurial website changed from `mercurial.selenic.com` to `mercurial-scm.org` some time ago, invalidating all links to it.