### PR TITLE
Added support to import/export queries as plain SQL & Fixed a bug in ImportProject

### DIFF
--- a/MSAccess-VCS/VCS_ImportExport.bas
+++ b/MSAccess-VCS/VCS_ImportExport.bas
@@ -36,7 +36,8 @@ Private Function IsNotVCS(ByVal name As String) As Boolean
       name <> "VCS_Reference" And _
       name <> "VCS_DataMacro" And _
       name <> "VCS_Report" And _
-      name <> "VCS_Relation" Then
+      name <> "VCS_Relation" And _
+      name <> "VCS_Query" Then
         IsNotVCS = True
     Else
         IsNotVCS = False
@@ -491,15 +492,27 @@ On Error GoTo errorHandler
             CurrentDb.Relations.Delete (rel.name)
         End If
     Next
-
+	
+	' First gather all Query Names. 
+	' If you delete right away, the iterator loses track and only deletes every 2nd Query
+	Dim toBeDeleted As Collection
+    Set toBeDeleted = New Collection
+    Dim qryName As Variant
+    
     Dim dbObject As Object
     For Each dbObject In Db.QueryDefs
         DoEvents
         If Left$(dbObject.name, 1) <> "~" Then
-'            Debug.Print dbObject.Name
-            Db.QueryDefs.Delete dbObject.name
+			toBeDeleted.Add dbObject.Name
         End If
     Next
+	
+	For Each qryName In toBeDeleted
+        Db.QueryDefs.Delete qryName
+        Debug.Print "Deleted: " & qryName
+    Next
+	
+	Set toBeDeleted = Nothing
     
     Dim td As DAO.TableDef
     For Each td In CurrentDb.TableDefs

--- a/MSAccess-VCS/VCS_ImportExport.bas
+++ b/MSAccess-VCS/VCS_ImportExport.bas
@@ -82,10 +82,10 @@ Public Sub ExportAllSource()
 			DoEvents
 			If Left$(qry.name, 1) <> "~" Then
 				If HandleQueriesAsSQL Then
-                                    VCS_Query.ExportQueryAsSQL qry, obj_path & qry.name & ".bas", False
-                                Else
-                                    VCS_IE_Functions.VCS_ExportObject acQuery, qry.name, obj_path & qry.name & ".bas", VCS_File.VCS_UsingUcs2
-                                End If
+                    VCS_Query.ExportQueryAsSQL qry, obj_path & qry.name & ".bas", False
+				Else
+					VCS_IE_Functions.VCS_ExportObject acQuery, qry.name, obj_path & qry.name & ".bas", VCS_File.VCS_UsingUcs2
+				End If
 				obj_count = obj_count + 1
 			End If
 		Next

--- a/MSAccess-VCS/VCS_ImportExport.bas
+++ b/MSAccess-VCS/VCS_ImportExport.bas
@@ -509,7 +509,6 @@ On Error GoTo errorHandler
 	
 	For Each qryName In toBeDeleted
         Db.QueryDefs.Delete qryName
-        Debug.Print "Deleted: " & qryName
     Next
 	
 	Set toBeDeleted = Nothing

--- a/MSAccess-VCS/VCS_Query.bas
+++ b/MSAccess-VCS/VCS_Query.bas
@@ -71,13 +71,13 @@ Public Sub ImportQueryFromSQL(ByVal obj_name As String, ByVal file_path As Strin
         Dim tempFileName As String
         tempFileName = VCS_File.VCS_TempFile()
         VCS_File.VCS_ConvertUtf8Ucs2 file_path, tempFileName
-        CurrentDb.CreateQueryDef(obj_name, readFromTextFile(file_path)).Close
+        CurrentDb.CreateQueryDef obj_name, readFromTextFile(file_path)
         
         Dim fso As Object
         Set fso = CreateObject("Scripting.FileSystemObject")
         fso.DeleteFile tempFileName
     Else
-        CurrentDb.CreateQueryDef(obj_name, readFromTextFile(file_path)).Close
+        CurrentDb.CreateQueryDef obj_name, readFromTextFile(file_path)
     End If
 
 End Sub

--- a/MSAccess-VCS/VCS_Query.bas
+++ b/MSAccess-VCS/VCS_Query.bas
@@ -1,0 +1,84 @@
+Attribute VB_Name = "VCS_Query"
+Option Compare Database
+Option Explicit
+
+Public Sub ExportQueryAsSQL(qry As QueryDef, ByVal file_path As String, _
+                            Optional ByVal Ucs2Convert As Boolean = False)
+
+    VCS_Dir.VCS_MkDirIfNotExist Left$(file_path, InStrRev(file_path, "\"))
+    If Ucs2Convert Then
+        Dim tempFileName As String
+        tempFileName = VCS_File.VCS_TempFile()
+        writeTextToFile qry.sql, tempFileName
+        VCS_File.VCS_ConvertUcs2Utf8 tempFileName, file_path
+    Else
+        writeTextToFile qry.sql, file_path
+    End If
+
+End Sub
+
+
+Private Sub writeTextToFile(ByVal text As String, ByVal file_path As String)
+    
+    Dim fso As Object
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Dim oFile As Object
+    Set oFile = fso.CreateTextFile(file_path)
+
+    oFile.WriteLine text
+    oFile.Close
+    
+    Set fso = Nothing
+    Set oFile = Nothing
+
+End Sub
+
+Private Function readFromTextFile(ByVal file_path As String) As String
+    
+    Dim textRead As String
+    Dim fso As Object
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Dim oFile As Object
+    Set oFile = fso.OpenTextFile(file_path, ForReading)
+    
+    
+    Do While Not oFile.AtEndOfStream
+
+        textRead = textRead & oFile.ReadLine & vbCrLf
+    
+    Loop
+
+    readFromTextFile = textRead
+    
+    oFile.Close
+    
+    Set fso = Nothing
+    Set oFile = Nothing
+
+End Function
+
+
+
+Public Sub ImportQueryFromSQL(ByVal obj_name As String, ByVal file_path As String, _
+                                Optional ByVal Ucs2Convert As Boolean = False)
+
+    If Not VCS_Dir.VCS_FileExists(file_path) Then Exit Sub
+    
+    Dim qry As QueryDef
+    
+    If Ucs2Convert Then
+        
+        Dim tempFileName As String
+        tempFileName = VCS_File.VCS_TempFile()
+        VCS_File.VCS_ConvertUtf8Ucs2 file_path, tempFileName
+        CurrentDb.CreateQueryDef(obj_name, readFromTextFile(file_path)).Close
+        
+        Dim fso As Object
+        Set fso = CreateObject("Scripting.FileSystemObject")
+        fso.DeleteFile tempFileName
+    Else
+        CurrentDb.CreateQueryDef(obj_name, readFromTextFile(file_path)).Close
+    End If
+
+End Sub
+


### PR DESCRIPTION
Hello,

i just found this project and its very useful, thanks for that!
When I tested it on one of my databases an error occured on reimporting queries. Most of the time I write my queries in plain SQL without using the GUI, that way you can create queries that are to complex for the GUI. The export though relied on it. 
So instead of using the built-in saveAsTextFile for queries, I just exported their SQL code. 
You can turn this off and on at the Import/Export configuration. Maybe someone else needs this too :)
A nice sideeffect is the readability of exported queries. 

Also I found a bug in the deletion process. When you delete queries while iterating over them, overy other query will be skipped. Fixed that along the way, though actually i quess this should have been a new pull request...

