### PR TITLE
Exclude VCS_Button_Functions from exported modules if ArchiveMyself is not activated

### DIFF
--- a/MSAccess-VCS/VCS_Button_Functions.bas
+++ b/MSAccess-VCS/VCS_Button_Functions.bas
@@ -1,4 +1,4 @@
-Attribute VB_Name = "VCS_buttonFunctions"
+Attribute VB_Name = "VCS_Button_Functions"
 Option Compare Database
 
 ' function to call update functions from button clicks

--- a/MSAccess-VCS/VCS_ImportExport.bas
+++ b/MSAccess-VCS/VCS_ImportExport.bas
@@ -39,7 +39,8 @@ Private Function IsNotVCS(ByVal name As String) As Boolean
       name <> "VCS_DataMacro" And _
       name <> "VCS_Report" And _
       name <> "VCS_Relation" And _
-      name <> "VCS_Query" Then
+      name <> "VCS_Query" And _
+      name <> "VCS_Button_Functions" Then
         IsNotVCS = True
     Else
         IsNotVCS = False
@@ -718,6 +719,7 @@ Exit_Proc:
 Err_Handle:
     Resume Exit_Proc
 End Function
+
 
 
 


### PR DESCRIPTION
The new file VCS_Button_Functions should also be excluded from the exported modules, if the ArchiveMyself Option is not activated. The file was added in #71 