### PR TITLE
Fix escape character removal in Table Data Import

### DIFF
--- a/MSAccess-VCS/VCS_String.bas
+++ b/MSAccess-VCS/VCS_String.bas
@@ -43,3 +43,23 @@ Public Function VCS_PadRight(ByVal Value As String, ByVal Count As Integer) As S
         VCS_PadRight = VCS_PadRight & Space$(Count - Len(Value))
     End If
 End Function
+
+' Remove escape characters
+Public Function VCS_RmEsc(Value As String) As String
+    Dim i As Integer
+    Dim nextChar As String
+    
+    i = InStr(1, Value, "\")
+    Do Until i = 0
+        nextChar = Mid(Value, i + 1, 1)
+        Select Case nextChar
+            Case "\"
+                Value = left(Value, i - 1) & "\" & Mid(Value, i + 2)
+            Case "n"
+                Value = left(Value, i - 1) & vbCrLf & Mid(Value, i + 2)
+            Case "r"
+                Value = left(Value, i - 1) & vbTab & Mid(Value, i + 2)
+        End Select
+        i = InStr(i + 1, Value, "\")
+    Loop
+End Function

--- a/MSAccess-VCS/VCS_Table.bas
+++ b/MSAccess-VCS/VCS_Table.bas
@@ -327,9 +327,7 @@ Public Sub VCS_ImportTableData(ByVal tblName As String, ByVal obj_path As String
                 If Len(Value) = 0 Then
                     Value = Null
                 Else
-                    Value = Replace(Value, "\t", vbTab)
-                    Value = Replace(Value, "\n", vbCrLf)
-                    Value = Replace(Value, "\\", "\")
+                    Value = VCS_String.VCS_RmEsc(Value)
                 End If
                 rs(fieldObj.Name) = Value
                 c = c + 1


### PR DESCRIPTION
If we take the string `"C:\\something\nothing.txt"`
Pass it through the **export**
```vba
    Value = Replace(Value, "\", "\\")
    Value = Replace(Value, vbCrLf, "\n")
    Value = Replace(Value, vbCr, "\n")
    Value = Replace(Value, vbLf, "\n")
    Value = Replace(Value, vbTab, "\t")
```
We get `"C:\\\\something\\nothing.txt"`
Then pass it through the **import**
```vba
    Value = Replace(Value, "\t", vbTab)
    Value = Replace(Value, "\n", vbCrLf)
    Value = Replace(Value, "\\", "\")
```
We get 
```
C:\\something\
othing.txt
```

This is what the `VCS_RmEsc` function is fixing